### PR TITLE
增加页写功能

### DIFF
--- a/at24cxx.c
+++ b/at24cxx.c
@@ -6,16 +6,17 @@
  * Change Logs:
  * Date           Author       Notes
  * 2019-04-13     XiaojieFan   the first version
+ * 2019-12-04     RenMing      ADD PAGE WRITE and input address can be selected 
  */
 #include <rtthread.h>
 #include <rtdevice.h>
 #include <board.h>
 
-
 #include <string.h>
+#include <stdlib.h>
 
 #define DBG_ENABLE
-#define DBG_SECTION_NAME "AHT10"
+#define DBG_SECTION_NAME "at24xx"
 #define DBG_LEVEL DBG_LOG
 #define DBG_COLOR
 #include <rtdbg.h>
@@ -23,18 +24,50 @@
 #include "at24cxx.h"
 
 #ifdef PKG_USING_AT24CXX
-#define AT24CXX_ADDR 0x50                      //A0 A1 A2 connect GND
+#define AT24CXX_ADDR (0xA0 >> 1)                      //A0 A1 A2 connect GND
 
-static rt_err_t read_regs(struct rt_i2c_bus_device *bus, rt_uint8_t len, rt_uint8_t *buf)
+#if (EE_TYPE == AT24C01)
+    #define AT24CXX_PAGE_BYTE               8
+    #define AT24CXX_MAX_MEM_ADDRESS         128
+#elif (EE_TYPE == AT24C02)
+    #define AT24CXX_PAGE_BYTE               8
+    #define AT24CXX_MAX_MEM_ADDRESS         256
+#elif (EE_TYPE == AT24C04)
+    #define AT24CXX_PAGE_BYTE               16
+    #define AT24CXX_MAX_MEM_ADDRESS         512
+#elif (EE_TYPE == AT24C08)
+    #define AT24CXX_PAGE_BYTE               16
+    #define AT24CXX_MAX_MEM_ADDRESS         1024
+#elif (EE_TYPE == AT24C16)
+    #define AT24CXX_PAGE_BYTE               16
+    #define AT24CXX_MAX_MEM_ADDRESS         2048
+#elif (EE_TYPE == AT24C32)
+    #define AT24CXX_PAGE_BYTE               32
+    #define AT24CXX_MAX_MEM_ADDRESS         4096
+#elif (EE_TYPE == AT24C64)
+    #define AT24CXX_PAGE_BYTE               32
+    #define AT24CXX_MAX_MEM_ADDRESS         8192
+#elif (EE_TYPE == AT24C128)
+    #define AT24CXX_PAGE_BYTE               64
+    #define AT24CXX_MAX_MEM_ADDRESS         16384
+#elif (EE_TYPE == AT24C256)
+    #define AT24CXX_PAGE_BYTE               64
+    #define AT24CXX_MAX_MEM_ADDRESS         32768
+#elif (EE_TYPE == AT24C512)
+    #define AT24CXX_PAGE_BYTE               128
+    #define AT24CXX_MAX_MEM_ADDRESS         65536
+#endif
+
+static rt_err_t read_regs(at24cxx_device_t dev, rt_uint8_t len, rt_uint8_t *buf)
 {
     struct rt_i2c_msg msgs;
 
-    msgs.addr = AT24CXX_ADDR;
+    msgs.addr = AT24CXX_ADDR | dev->AddrInput;
     msgs.flags = RT_I2C_RD;
     msgs.buf = buf;
     msgs.len = len;
 
-    if (rt_i2c_transfer(bus, &msgs, 1) == 1)
+    if (rt_i2c_transfer(dev->i2c, &msgs, 1) == 1)
     {
         return RT_EOK;
     }
@@ -43,7 +76,7 @@ static rt_err_t read_regs(struct rt_i2c_bus_device *bus, rt_uint8_t len, rt_uint
         return -RT_ERROR;
     }
 }
-uint8_t at24cxx_read_one_byte(struct rt_i2c_bus_device *bus, uint16_t readAddr)
+uint8_t at24cxx_read_one_byte(at24cxx_device_t dev, uint16_t readAddr)
 {
     rt_uint8_t buf[2];
     rt_uint8_t temp;
@@ -53,16 +86,16 @@ uint8_t at24cxx_read_one_byte(struct rt_i2c_bus_device *bus, uint16_t readAddr)
     if (rt_i2c_master_send(bus, AT24CXX_ADDR, 0, buf, 2) == 0) 
 #else
     buf[0] = readAddr;
-    if (rt_i2c_master_send(bus, AT24CXX_ADDR, 0, buf, 1) == 0)
+    if (rt_i2c_master_send(dev->i2c, AT24CXX_ADDR | dev->AddrInput, 0, buf, 1) == 0)
 #endif        
     {
-        return -RT_ERROR;
+        return RT_ERROR;
     }
-    read_regs(bus, 1, &temp);
+    read_regs(dev, 1, &temp);
     return temp;
 }
 
-rt_err_t at24cxx_write_one_byte(struct rt_i2c_bus_device *bus, uint16_t writeAddr, uint8_t dataToWrite)
+rt_err_t at24cxx_write_one_byte(at24cxx_device_t dev, uint16_t writeAddr, uint8_t dataToWrite)
 {
     rt_uint8_t buf[3];
 #if	(EE_TYPE > AT24C16)      
@@ -76,7 +109,7 @@ rt_err_t at24cxx_write_one_byte(struct rt_i2c_bus_device *bus, uint16_t writeAdd
     //buf[2] = data[1];
     
 
-    if (rt_i2c_master_send(bus, AT24CXX_ADDR, 0, buf, 2) == 2)
+    if (rt_i2c_master_send(dev->i2c, AT24CXX_ADDR | dev->AddrInput, 0, buf, 2) == 2)
 #endif        
         return RT_EOK;
     else
@@ -84,18 +117,82 @@ rt_err_t at24cxx_write_one_byte(struct rt_i2c_bus_device *bus, uint16_t writeAdd
 
 }
 
+rt_err_t at24cxx_read_page(at24cxx_device_t dev, uint32_t readAddr, uint8_t *pBuffer, uint16_t numToRead)
+{
+    struct rt_i2c_msg msgs[2];
+    uint8_t AddrBuf[2];
+    
+    msgs[0].addr = AT24CXX_ADDR | dev->AddrInput;
+    msgs[0].flags = RT_I2C_WR ;
+ 
+#if	(EE_TYPE > AT24C16) 
+    AddrBuf[0] = readAddr >> 8;
+    AddrBuf[1] = readAddr;
+	msgs[0].buf = AddrBuf;
+    msgs[0].len = 2; 
+#else
+    AddrBuf[0] = readAddr;
+	msgs[0].buf = AddrBuf;
+    msgs[0].len = 1;
+#endif    
+    
+    msgs[1].addr = AT24CXX_ADDR | dev->AddrInput;
+    msgs[1].flags = RT_I2C_RD;
+    msgs[1].buf = pBuffer;
+    msgs[1].len = numToRead;
+    
+    if(rt_i2c_transfer(dev->i2c, msgs, 2) == 0) 
+    {
+        return RT_ERROR;
+    }			
+	
+    return RT_EOK;
+}
+
+rt_err_t at24cxx_write_page(at24cxx_device_t dev, uint32_t wirteAddr, uint8_t *pBuffer, uint16_t numToWrite)
+{
+    struct rt_i2c_msg msgs[2];
+    uint8_t AddrBuf[2];
+
+    msgs[0].addr = AT24CXX_ADDR | dev->AddrInput;
+    msgs[0].flags = RT_I2C_WR ;
+    
+#if	(EE_TYPE > AT24C16) 
+    AddrBuf[0] = wirteAddr >> 8;
+    AddrBuf[1] = wirteAddr;
+	msgs[0].buf = AddrBuf;
+    msgs[0].len = 2; 
+#else
+    AddrBuf[0] = wirteAddr;
+	msgs[0].buf = AddrBuf;
+    msgs[0].len = 1;
+#endif    
+	  
+    msgs[1].addr = AT24CXX_ADDR | dev->AddrInput;
+    msgs[1].flags = RT_I2C_WR | RT_I2C_NO_START;
+    msgs[1].buf = pBuffer;
+    msgs[1].len = numToWrite;
+	  
+    if(rt_i2c_transfer(dev->i2c, msgs, 2) == 0) 
+    {
+        return RT_ERROR;
+    }			
+	
+    return RT_EOK;	
+}
+
 rt_err_t at24cxx_check(at24cxx_device_t dev)
 {
     uint8_t temp;
-    rt_err_t result;
     RT_ASSERT(dev);
 
-    temp = at24cxx_read_one_byte(dev->i2c, 255);
+    temp = at24cxx_read_one_byte(dev, AT24CXX_MAX_MEM_ADDRESS - 1);
     if (temp == 0x55) return RT_EOK;
     else
     {
-        at24cxx_write_one_byte(dev->i2c, 255, 0x55);
-        temp = at24cxx_read_one_byte(dev->i2c, 255);
+        at24cxx_write_one_byte(dev, AT24CXX_MAX_MEM_ADDRESS - 1, 0x55);
+        rt_thread_mdelay(EE_TWR);                 // wait 5ms befor next operation
+        temp = at24cxx_read_one_byte(dev, AT24CXX_MAX_MEM_ADDRESS - 1);
         if (temp == 0x55) return RT_EOK;
     }
     return RT_ERROR;
@@ -110,16 +207,22 @@ rt_err_t at24cxx_check(at24cxx_device_t dev)
  * @param NumToRead
  * @return RT_EOK  write ok.
  */
-rt_err_t at24cxx_read(at24cxx_device_t dev, uint16_t ReadAddr, uint8_t *pBuffer, uint16_t NumToRead)
+rt_err_t at24cxx_read(at24cxx_device_t dev, uint32_t ReadAddr, uint8_t *pBuffer, uint16_t NumToRead)
 {
     rt_err_t result;
     RT_ASSERT(dev);
+    
+    if(ReadAddr + NumToRead > AT24CXX_MAX_MEM_ADDRESS)
+    {
+        return RT_ERROR;
+    }
+    
     result = rt_mutex_take(dev->lock, RT_WAITING_FOREVER);
     if (result == RT_EOK)
     {
         while (NumToRead)
         {
-            *pBuffer++ = at24cxx_read_one_byte(dev->i2c, ReadAddr++);
+            *pBuffer++ = at24cxx_read_one_byte(dev, ReadAddr++);
             NumToRead--;
         }
     }
@@ -133,6 +236,63 @@ rt_err_t at24cxx_read(at24cxx_device_t dev, uint16_t ReadAddr, uint8_t *pBuffer,
 }
 
 /**
+ * This function read the specific numbers of data to the specific position
+ *
+ * @param bus the name of at24cxx device
+ * @param ReadAddr the start position to read
+ * @param pBuffer  the read data store position
+ * @param NumToRead 
+ * @return RT_EOK  write ok.
+ */
+rt_err_t at24cxx_page_read(at24cxx_device_t dev, uint32_t ReadAddr, uint8_t *pBuffer, uint16_t NumToRead)
+{
+    rt_err_t result = RT_EOK;
+    uint16_t pageReadSize = AT24CXX_PAGE_BYTE - ReadAddr % AT24CXX_PAGE_BYTE;
+	  
+    RT_ASSERT(dev);
+	
+    if(ReadAddr + NumToRead > AT24CXX_MAX_MEM_ADDRESS)
+    {
+        return RT_ERROR;
+    }
+
+    result = rt_mutex_take(dev->lock, RT_WAITING_FOREVER);
+    if(result == RT_EOK)
+    {
+        while (NumToRead)
+        {
+            if(NumToRead > pageReadSize)
+            {
+                if(at24cxx_read_page(dev, ReadAddr, pBuffer, pageReadSize))
+                {
+                    result = RT_ERROR;
+                }
+
+                ReadAddr += pageReadSize;
+                pBuffer += pageReadSize;
+                NumToRead -= pageReadSize;
+                pageReadSize = AT24CXX_PAGE_BYTE;
+            }
+            else
+            {
+                if(at24cxx_read_page(dev, ReadAddr, pBuffer, NumToRead))
+                {
+                    result = RT_ERROR;
+                }
+                NumToRead = 0;
+            }
+        }
+    }
+    else
+    {
+        LOG_E("The at24cxx could not respond  at this time. Please try again");
+    }
+				
+    rt_mutex_release(dev->lock);
+    return result;
+}
+
+/**
  * This function write the specific numbers of data to the specific position
  *
  * @param bus the name of at24cxx device
@@ -141,17 +301,23 @@ rt_err_t at24cxx_read(at24cxx_device_t dev, uint16_t ReadAddr, uint8_t *pBuffer,
  * @param NumToWrite
  * @return RT_EOK  write ok.at24cxx_device_t dev
  */
-rt_err_t at24cxx_write(at24cxx_device_t dev, uint16_t WriteAddr, uint8_t *pBuffer, uint16_t NumToWrite)
+rt_err_t at24cxx_write(at24cxx_device_t dev, uint32_t WriteAddr, uint8_t *pBuffer, uint16_t NumToWrite)
 {
     uint16_t i = 0;
     rt_err_t result;
     RT_ASSERT(dev);
+    
+    if(WriteAddr + NumToWrite > AT24CXX_MAX_MEM_ADDRESS)
+    {
+        return RT_ERROR;
+    }
+    
     result = rt_mutex_take(dev->lock, RT_WAITING_FOREVER);
     if (result == RT_EOK)
     {
         while (1) //NumToWrite--
         {
-            if (at24cxx_write_one_byte(dev->i2c, WriteAddr, pBuffer[i]) != RT_EOK)
+            if (at24cxx_write_one_byte(dev, WriteAddr, pBuffer[i]) != RT_EOK)
             {
                 rt_thread_mdelay(EE_TWR);
             }
@@ -175,6 +341,67 @@ rt_err_t at24cxx_write(at24cxx_device_t dev, uint16_t WriteAddr, uint8_t *pBuffe
 
     return RT_EOK;
 }
+
+/**
+ * This function write the specific numbers of data to the specific position
+ *
+ * @param bus the name of at24cxx device
+ * @param WriteAddr the start position to write
+ * @param pBuffer  the data need to write
+ * @param NumToWrite
+ * @return RT_EOK  write ok.at24cxx_device_t dev
+ */
+rt_err_t at24cxx_page_write(at24cxx_device_t dev, uint32_t WriteAddr, uint8_t *pBuffer, uint16_t NumToWrite)
+{
+    rt_err_t result = RT_EOK;
+    uint16_t pageWriteSize = AT24CXX_PAGE_BYTE - WriteAddr % AT24CXX_PAGE_BYTE;
+	  
+    RT_ASSERT(dev);
+	
+    if(WriteAddr + NumToWrite > AT24CXX_MAX_MEM_ADDRESS)
+    {
+        return RT_ERROR;
+    }
+
+    result = rt_mutex_take(dev->lock, RT_WAITING_FOREVER);
+    if(result == RT_EOK)
+    {
+        while (NumToWrite)
+        {
+            if(NumToWrite > pageWriteSize)
+            {
+                if(at24cxx_write_page(dev, WriteAddr, pBuffer, pageWriteSize))
+                {
+                    result = RT_ERROR;
+                }
+                rt_thread_mdelay(EE_TWR);    // wait 5ms befor next operation
+
+                WriteAddr += pageWriteSize;
+                pBuffer += pageWriteSize;
+                NumToWrite -= pageWriteSize;
+                pageWriteSize = AT24CXX_PAGE_BYTE;
+            }
+            else
+            {
+                if(at24cxx_write_page(dev, WriteAddr, pBuffer, NumToWrite))
+                {
+                    result = RT_ERROR;
+                }
+                rt_thread_mdelay(EE_TWR);   // wait 5ms befor next operation
+
+                NumToWrite = 0;
+            }
+        }
+    }
+    else
+    {
+        LOG_E("The at24cxx could not respond  at this time. Please try again");
+    }
+
+    rt_mutex_release(dev->lock);
+    return result;
+}
+
 /**
  * This function initializes at24cxx registered device driver
  *
@@ -182,7 +409,7 @@ rt_err_t at24cxx_write(at24cxx_device_t dev, uint16_t WriteAddr, uint8_t *pBuffe
  *
  * @return the at24cxx device.
  */
-at24cxx_device_t at24cxx_init(const char *i2c_bus_name)
+at24cxx_device_t at24cxx_init(const char *i2c_bus_name, uint8_t AddrInput)
 {
     at24cxx_device_t dev;
 
@@ -211,6 +438,7 @@ at24cxx_device_t at24cxx_init(const char *i2c_bus_name)
         return RT_NULL;
     }
 
+    dev->AddrInput = AddrInput;
     return dev;
 }
 
@@ -249,12 +477,12 @@ void at24cxx(int argc, char *argv[])
                     {
                         at24cxx_deinit(dev);
                     }
-                    dev = at24cxx_init(argv[2]);
+                    dev = at24cxx_init(argv[2], atoi(argv[3]));
                 }
             }
             else
             {
-                rt_kprintf("at24cxx probe <dev_name>   - probe sensor by given name\n");
+                rt_kprintf("at24cxx probe <dev_name> <AddrInput> - probe sensor by given name\n");
             }
         }
         else if (!strcmp(argv[1], "read"))

--- a/at24cxx.h
+++ b/at24cxx.h
@@ -6,6 +6,7 @@
  * Change Logs:
  * Date           Author       Notes
  * 2019-04-13     XiaojieFan   the first version
+ * 2019-12-04     RenMing      Use PAGE WRITE instead of BYTE WRITE and input address can be selected 
  */
 
 #ifndef __AT24CXX_H__
@@ -17,23 +18,33 @@
 #include <rthw.h>
 #include <rtdevice.h>
 
-#define AT24C01     127
-#define AT24C02     255
-#define AT24C04     511
-#define AT24C08     1023
-#define AT24C16     2047
-#define AT24C32     4095
-#define AT24C64     8191
-#define AT24C128    16383
-#define AT24C256    32767
-#define AT24C512    65535
+#define AT24C01     0
+#define AT24C02     1
+#define AT24C04     2
+#define AT24C08     3
+#define AT24C16     4
+#define AT24C32     5
+#define AT24C64     6
+#define AT24C128    7
+#define AT24C256    8
+#define AT24C512    9
+#define AT24CTYPE   10   // Number of supported types
 
-#define EE_TWR  5
-#define EE_TYPE AT24C512
+#define EE_TWR      5
+#define EE_TYPE     AT24C02
+
 struct at24cxx_device
 {
     struct rt_i2c_bus_device *i2c;
     rt_mutex_t lock;
+    uint8_t AddrInput;
 };
 typedef struct at24cxx_device *at24cxx_device_t;
+
+extern at24cxx_device_t at24cxx_init(const char *i2c_bus_name, uint8_t AddrInput);
+extern rt_err_t at24cxx_read(at24cxx_device_t dev, uint32_t ReadAddr, uint8_t *pBuffer, uint16_t NumToRead);
+extern rt_err_t at24cxx_write(at24cxx_device_t dev, uint32_t WriteAddr, uint8_t *pBuffer, uint16_t NumToWrite);
+extern rt_err_t at24cxx_page_read(at24cxx_device_t dev, uint32_t ReadAddr, uint8_t *pBuffer, uint16_t NumToRead);
+extern rt_err_t at24cxx_page_write(at24cxx_device_t dev, uint32_t WriteAddr, uint8_t *pBuffer, uint16_t NumToWrite);
+
 #endif


### PR DESCRIPTION
1：增加AT24C系列的页写和页读功能。
2：增加AT24CXX_PAGE_BYTE以及AT24CXX_MAX_MEM_ADDRESS来确定页写的参数。
3：增加地址可设，用于处理多个AT24xx同一种芯片同时挂载到同一iic总线的情况。
4：并不影响原有功能的实现
5：增加了最大内存地址的判断，考虑到AT24C512，将读地址改为uint32_t防止计算溢出
6：仅在AT24C02进行了简单测试