### PR TITLE
1.<at24cxx.h>增加了<board.h>头文件的引入，使用rt-thread studio可以在<board.h>中定义板载EE…

### DIFF
--- a/at24cxx.c
+++ b/at24cxx.c
@@ -83,7 +83,7 @@ uint8_t at24cxx_read_one_byte(at24cxx_device_t dev, uint16_t readAddr)
 #if	(EE_TYPE > AT24C16)  
     buf[0] = (uint8_t)(readAddr>>8);	
     buf[1] = (uint8_t)readAddr;
-    if (rt_i2c_master_send(bus, AT24CXX_ADDR, 0, buf, 2) == 0) 
+    if (rt_i2c_master_send(dev->i2c, AT24CXX_ADDR, 0, buf, 2) == 0) 
 #else
     buf[0] = readAddr;
     if (rt_i2c_master_send(dev->i2c, AT24CXX_ADDR | dev->AddrInput, 0, buf, 1) == 0)
@@ -102,7 +102,7 @@ rt_err_t at24cxx_write_one_byte(at24cxx_device_t dev, uint16_t writeAddr, uint8_
     buf[0] = (uint8_t)(writeAddr>>8);	
     buf[1] = (uint8_t)writeAddr;
     buf[2] = dataToWrite;
-    if (rt_i2c_master_send(bus, AT24CXX_ADDR, 0, buf, 3) == 3)    
+    if (rt_i2c_master_send(dev->i2c, AT24CXX_ADDR, 0, buf, 3) == 3)    
 #else    
     buf[0] = writeAddr; //cmd
     buf[1] = dataToWrite;

--- a/at24cxx.h
+++ b/at24cxx.h
@@ -14,9 +14,8 @@
 
 #include <rthw.h>
 #include <rtthread.h>
-
-#include <rthw.h>
 #include <rtdevice.h>
+#include <board.h>
 
 #define AT24C01     0
 #define AT24C02     1
@@ -31,7 +30,10 @@
 #define AT24CTYPE   10   // Number of supported types
 
 #define EE_TWR      5
+
+#ifndef EE_TYPE
 #define EE_TYPE     AT24C02
+#endif
 
 struct at24cxx_device
 {


### PR DESCRIPTION
…PROM的类型;

2.<at24cxx.h>增加了EE_TYPE定义检查，如果<board.h>中未定义EE_TYPE才默认定义EE_TYPE为AT_24C02，用户不需要修改package源码;
3.<at24cxx.c>修复了EE_TYPE > AT24C16时，at24cxx_read_one_byte和at24cxx_write_one_byte函数中rt_i2c_master_send参数错误的问题;